### PR TITLE
Fix to double counting reads that have sup aln

### DIFF
--- a/nanoget/extraction_functions.py
+++ b/nanoget/extraction_functions.py
@@ -223,7 +223,7 @@ def extract_from_bam(params):
          read.mapping_quality,
          get_pID(read))
         for read in samfile.fetch(reference=chromosome, multiple_iterators=True)
-        if not read.is_secondary and not read.is_unmapped]
+        if not read.is_secondary and not read.is_unmapped and not read.is_supplementary]
 
 
 def get_pID(read):


### PR DESCRIPTION
Fixed the issue of double counting reads in bam files with supplementary alignment. See issue #17.