### PR TITLE
Bump BAM ref-contig multi-process threshold to 200

### DIFF
--- a/nanoget/extraction_functions.py
+++ b/nanoget/extraction_functions.py
@@ -154,8 +154,8 @@ def process_bam(bam, **kwargs):
     logging.info("Nanoget: Starting to collect statistics from bam file {}.".format(bam))
     samfile = check_bam(bam)
     chromosomes = samfile.references
-    if len(chromosomes) > 100 or kwargs["huge"]:
-        logging.info("Nanoget: lots of contigs (>100) or --huge, not running in separate processes")
+    if len(chromosomes) > 200 or kwargs["huge"]:
+        logging.info("Nanoget: lots of contigs (>200) or --huge, not running in separate processes")
         datadf = pd.DataFrame(
             data=extract_from_bam(bam, None, kwargs["keep_supp"]),
             columns=["readIDs", "quals", "aligned_quals", "lengths",


### PR DESCRIPTION
When processing aligned BAM, if the number of contigs in the reference is beyond a threshold, the BAM is processed with a single process.

This PR bumps that threshold to a higher number of 200. This number is based on the fact that the "no_alt" analysis set of the GRCh38 reference has 195 contigs, therefore just below this new threshold so that human BAMs can be processed parallel.

See original [ticket](https://github.com/wdecoster/NanoPlot/issues/306) over at Nanoplot.

Thanks!
Steve