### PR TITLE
fix: convert timezone aware to naive for fastq rich

### DIFF
--- a/nanoget/extraction_functions.py
+++ b/nanoget/extraction_functions.py
@@ -8,7 +8,8 @@ import re
 from Bio import SeqIO
 import concurrent.futures as cfutures
 from itertools import repeat
-
+import datetime
+import pytz
 
 def process_summary(summaryfile, **kwargs):
     """Extracting information from an albacore summary file.
@@ -475,6 +476,7 @@ def process_fastq_rich(fastq, **kwargs):
     df = pd.DataFrame(
         data=res, columns=["quals", "lengths", "channelIDs", "timestamp", "runIDs"]
     ).dropna()
+    df['timestamp'] = [datetime.datetime.fromisoformat(q).astimezone(pytz.UTC).replace(tzinfo=None) for q in df['timestamp']]
     df["timestamp"] = df["timestamp"].astype("datetime64[ns]")
     df["channelIDs"] = df["channelIDs"].astype("int64")
     return ut.reduce_memory_usage(df)


### PR DESCRIPTION
Hi, thanks for these amazing libraries you made :)

I keep getting an error when processing fastq rich data from MinIon with Nanoplot, and it seems the problem leads to this script. I get this error message:
`TypeError: Cannot use .astype to convert from timezone-aware dtype to timezone-naive dtype. Use obj.tz_localize(None) or obj.tz_convert('UTC').tz_localize(None) instead.`

This PR attempts to:
- Fix the issue caused by numpy's deprecated parsing of timezone aware datetimes: https://numpy.org/doc/stable/release/1.11.0-notes.html#datetime64-changes 
- Here, the datetime was first converted to UTC time zone using `astimezone() `method and then the timezone information was removed using `replace()` method with `tzinfo` parameter set to `None`.
- I only changed the fastq_rich parser, so maybe apply the fastq_minimal?

PS: I'm quite new to programming so not sure if this is the best approach. 
