### PR TITLE
function for converting to correct timezone

### DIFF
--- a/nanoget/nanoget.py
+++ b/nanoget/nanoget.py
@@ -150,7 +150,7 @@ def calculate_start_time(df):
     if "time" in df.columns:
         df["time_arr"] = pd.Series(df["time"], dtype="datetime64[s]")
     elif "timestamp" in df.columns:
-        df["time_arr"] = df["timestamp"]
+        df["time_arr"] = df["timestamp"].dt.tz_convert('UTC').dt.tz_localize(None)
     else:
         return df
     if "dataset" in df.columns:


### PR DESCRIPTION
Hi @wdecoster,

I was getting the following error using Nanoplot on an Ubuntu box with non standard time zone settings.
The error was:
```
If you read this then NanoPlot 1.41.6 has crashed :-(
Please try updating NanoPlot and see if that helps...

If not, please report this issue at https://github.com/wdecoster/NanoPlot/issues
If you could include the log file that would be really helpful.
Thanks!



concurrent.futures.process._RemoteTraceback:
"""
Traceback (most recent call last):
  File "/home/tvangurp/micromamba/envs/nanotools/lib/python3.10/concurrent/futures/process.py", line 246, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "/home/tvangurp/micromamba/envs/nanotools/lib/python3.10/concurrent/futures/process.py", line 205, in _process_chunk
    return [fn(*args) for args in chunk]
  File "/home/tvangurp/micromamba/envs/nanotools/lib/python3.10/concurrent/futures/process.py", line 205, in <listcomp>
    return [fn(*args) for args in chunk]
  File "/home/tvangurp/micromamba/envs/nanotools/lib/python3.10/site-packages/nanoget/extraction_functions.py", line 478, in process_fastq_rich
    df["timestamp"] = df["timestamp"].astype("datetime64[ns]")
  File "/home/tvangurp/micromamba/envs/nanotools/lib/python3.10/site-packages/pandas/core/generic.py", line 6324, in astype
    new_data = self._mgr.astype(dtype=dtype, copy=copy, errors=errors)
  File "/home/tvangurp/micromamba/envs/nanotools/lib/python3.10/site-packages/pandas/core/internals/managers.py", line 451, in astype
    return self.apply(
  File "/home/tvangurp/micromamba/envs/nanotools/lib/python3.10/site-packages/pandas/core/internals/managers.py", line 352, in apply
    applied = getattr(b, f)(**kwargs)
  File "/home/tvangurp/micromamba/envs/nanotools/lib/python3.10/site-packages/pandas/core/internals/blocks.py", line 511, in astype
    new_values = astype_array_safe(values, dtype, copy=copy, errors=errors)
  File "/home/tvangurp/micromamba/envs/nanotools/lib/python3.10/site-packages/pandas/core/dtypes/astype.py", line 242, in astype_array_safe
    new_values = astype_array(values, dtype, copy=copy)
  File "/home/tvangurp/micromamba/envs/nanotools/lib/python3.10/site-packages/pandas/core/dtypes/astype.py", line 187, in astype_array
    values = _astype_nansafe(values, dtype, copy=copy)
  File "/home/tvangurp/micromamba/envs/nanotools/lib/python3.10/site-packages/pandas/core/dtypes/astype.py", line 116, in _astype_nansafe
    return dta.astype(dtype, copy=False)._ndarray
  File "/home/tvangurp/micromamba/envs/nanotools/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py", line 682, in astype
    raise TypeError(
TypeError: Cannot use .astype to convert from timezone-aware dtype to timezone-naive dtype. Use obj.tz_localize(None) or obj.tz_convert('UTC').tz_localize(None) instead.
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/tvangurp/micromamba/envs/nanotools/bin/NanoPlot", line 10, in <module>
    sys.exit(main())
  File "/home/tvangurp/micromamba/envs/nanotools/lib/python3.10/site-packages/nanoplot/NanoPlot.py", line 61, in main
    datadf = get_input(
  File "/home/tvangurp/micromamba/envs/nanotools/lib/python3.10/site-packages/nanoget/nanoget.py", line 110, in get_input
    dfs=[out for out in executor.map(extraction_function, files)],
  File "/home/tvangurp/micromamba/envs/nanotools/lib/python3.10/site-packages/nanoget/nanoget.py", line 110, in <listcomp>
    dfs=[out for out in executor.map(extraction_function, files)],
  File "/home/tvangurp/micromamba/envs/nanotools/lib/python3.10/concurrent/futures/process.py", line 570, in _chain_from_iterable_of_lists
    for element in iterable:
  File "/home/tvangurp/micromamba/envs/nanotools/lib/python3.10/concurrent/futures/_base.py", line 621, in result_iterator
    yield _result_or_cancel(fs.pop())
  File "/home/tvangurp/micromamba/envs/nanotools/lib/python3.10/concurrent/futures/_base.py", line 319, in _result_or_cancel
    return fut.result(timeout)
  File "/home/tvangurp/micromamba/envs/nanotools/lib/python3.10/concurrent/futures/_base.py", line 458, in result
    return self.__get_result()
  File "/home/tvangurp/micromamba/envs/nanotools/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
TypeError: Cannot use .astype to convert from timezone-aware dtype to timezone-naive dtype. Use obj.tz_localize(None) or obj.tz_convert('UTC').tz_localize(None) instead.
```

I fixed it with the following change in nanoget.
lin 153: `df["time_arr"] = df["timestamp"] becomes `df["time_arr"] = df["timestamp"].dt.tz_convert('UTC').dt.tz_localize(None)`.

I have tested it, no more errors :-)